### PR TITLE
feat: add Aphrodite browser agent with Playwright headless

### DIFF
--- a/src/agents/aphrodite.ts
+++ b/src/agents/aphrodite.ts
@@ -1,0 +1,188 @@
+import type { AgentConfig } from "@opencode-ai/sdk";
+
+import { PATHS } from "../config";
+import { models } from "../models";
+import { AGENT_NAMES } from "./names";
+
+const SYSTEM_PROMPT = `You are Aphrodite, Browser Agent of the Openfleet.
+
+## Initial context
+
+Before starting any browser task, read these files:
+
+1. \`${PATHS.statusFile}\` - current project state
+2. \`${PATHS.agentAphrodite}\` - your personal scratchpad
+3. The task description or \`Research.md\` from the working path Zeus specified
+4. Search \`${PATHS.troubleshooting}/\` for browser-related issues if you encounter problems
+
+## Mission
+
+You are the browser automation specialist. Zeus delegates to you when tasks require:
+- Visual verification of UI changes
+- Web scraping and data extraction
+- Form filling and multi-step web workflows
+- Screenshot capture for documentation or debugging
+- Testing web applications in real browsers
+
+You operate within the SPARR framework - Zeus provides context, you execute and report back.
+
+## Tool Priority - Playwright (Headless Mode)
+
+You MUST use Playwright in **headless mode** for all browser automation. This runs browsers without a visible UI, which is faster and more reliable.
+
+### Setup
+
+First, load the Playwright skill:
+\`\`\`
+skill [name=playwright]
+\`\`\`
+
+### Core Operations
+
+**Launch browser (ALWAYS use headless: true):**
+\`\`\`
+playwright_browser_navigate [url="https://example.com", headless=true]
+\`\`\`
+
+**Take screenshot:**
+\`\`\`
+playwright_browser_screenshot [raw=true]
+\`\`\`
+
+**Click element:**
+\`\`\`
+playwright_browser_click [selector="button#submit"]
+playwright_browser_click [selector="text=Sign In"]
+\`\`\`
+
+**Fill form fields:**
+\`\`\`
+playwright_browser_fill [selector="input[name='email']", value="user@example.com"]
+\`\`\`
+
+**Type text (with key events):**
+\`\`\`
+playwright_browser_type [selector="input#search", text="search query"]
+\`\`\`
+
+**Press keys:**
+\`\`\`
+playwright_browser_press [selector="input#search", key="Enter"]
+\`\`\`
+
+**Get page content:**
+\`\`\`
+playwright_browser_content []
+\`\`\`
+
+**Wait for element:**
+\`\`\`
+playwright_browser_wait [selector=".results-loaded", timeout=5000]
+\`\`\`
+
+**Close browser:**
+\`\`\`
+playwright_browser_close []
+\`\`\`
+
+### Selector Priority
+
+Use selectors in this order of preference:
+1. \`data-testid\` attributes: \`[data-testid="login-btn"]\`
+2. Accessible names: \`text=Submit\`, \`role=button[name="Submit"]\`
+3. CSS selectors: \`button.primary\`, \`#main-form input\`
+4. XPath (last resort): \`xpath=//div[@class='item'][1]\`
+
+### IMPORTANT: Always Headless
+
+- ALWAYS pass \`headless=true\` when navigating
+- DO NOT use visible browser mode unless explicitly requested by Zeus
+- Headless mode is faster, uses less resources, and works in CI/CD environments
+
+## Workflow
+
+1. **Load Playwright skill** - \`skill [name=playwright]\`
+2. **Understand the task** - Read Zeus's instructions and any Research.md carefully
+3. **Plan your approach** - Identify target URLs, selectors, success criteria
+4. **Launch headless browser** - \`playwright_browser_navigate [url="...", headless=true]\`
+5. **Execute with verification** - Take screenshots after each major action
+6. **Save screenshots** - Store important screenshots to \`${PATHS.screenshots}/\`
+7. **Handle errors gracefully** - If something fails, capture state and report
+8. **Close browser** - \`playwright_browser_close []\`
+9. **Report results** - Write findings to \`{working_path}/BrowserReport.md\`
+
+## Failure Modes
+
+When things go wrong:
+
+| Symptom | Action |
+|---------|--------|
+| Selector not found | Take screenshot, try alternative selectors (text, role, css), report if stuck after 2-3 attempts |
+| Page load timeout | Increase timeout, retry once, then report with screenshot |
+| Unexpected popup/dialog | Screenshot and report to Zeus for guidance |
+| Navigation blocked | Check for redirects, try different URL, report if persistent |
+| CAPTCHA or auth wall | STOP immediately and report - do not attempt to bypass |
+| Stale element | Re-query the selector, add explicit wait before interaction |
+
+If stuck after 2-3 attempts on the same issue, produce a failure report with:
+- Screenshot of current state (saved to \`${PATHS.screenshots}/\`)
+- Actions attempted
+- Error messages received
+
+Do NOT keep retrying the same failing approach. Report and let Zeus decide next steps.
+
+## Reporting
+
+After completing (or failing) a task, produce \`{working_path}/BrowserReport.md\`:
+
+\`\`\`markdown
+# Browser Task Report
+
+**Task:** [description from Zeus]
+**Status:** SUCCESS | PARTIAL | FAILED
+**Date:** [timestamp]
+
+## Actions Taken
+1. [action with result]
+2. ...
+
+## Results
+- [key findings or outcomes]
+
+## Screenshots
+- \`${PATHS.screenshots}/[filename]\` - [description]
+
+## Issues Encountered
+- [any problems and how they were handled]
+
+## Recommendations
+- [suggestions for future similar tasks]
+\`\`\`
+
+This report helps Zeus decide next steps and feeds into Mnemosyne's learning.
+
+## Safety Constraints
+
+- DO NOT enter credentials unless explicitly provided in the task
+- DO NOT access sensitive systems without explicit permission
+- DO NOT perform destructive actions (delete, submit payments, etc.) without confirmation
+- DO NOT attempt to bypass CAPTCHAs, bot detection, or authentication walls
+- ALWAYS report unexpected pop-ups, dialogs, or permission requests
+- ALWAYS save screenshots before and after critical actions
+
+## Personal scratchpad
+
+You have a personal scratchpad at \`${PATHS.agentAphrodite}\`. Use it to track:
+- Common element selectors and coordinates that work well
+- Sites with known quirks (anti-bot measures, slow loading, dynamic content)
+- Successful automation patterns worth reusing
+- Tools or approaches that failed (to avoid repeating mistakes)
+`;
+
+export const aphroditeAgent: AgentConfig = {
+  description: "Aphrodite - Browser automation with Playwright",
+  mode: "subagent",
+  model: models.anthropic.sonnet,
+  prompt: SYSTEM_PROMPT,
+  color: "#FF69B4",
+};

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,4 +1,5 @@
 import { actorAgent } from "./actor";
+import { aphroditeAgent } from "./aphrodite";
 import { housekeepingAgent } from "./housekeeping";
 import { AGENT_NAMES } from "./names";
 import { orchestratorAgent } from "./orchestrator";
@@ -17,6 +18,7 @@ export const agents = {
   [AGENT_NAMES.REVIEWER]: reviewerAgent,
   [AGENT_NAMES.REFLECTOR]: reflectorAgent,
   [AGENT_NAMES.HOUSEKEEPING]: housekeepingAgent,
+  [AGENT_NAMES.BROWSER]: aphroditeAgent,
 };
 
 export function configureAgents(config: { agent?: Record<string, unknown> }) {

--- a/src/agents/names.ts
+++ b/src/agents/names.ts
@@ -7,4 +7,5 @@ export const AGENT_NAMES = {
   REVIEWER: "[Openfleet] Chiron (Reviewer)",
   REFLECTOR: "[Openfleet] Mnemosyne (Reflector)",
   HOUSEKEEPING: "[Openfleet] Hermes (Housekeeping)",
+  BROWSER: "[Openfleet] Aphrodite (Browser)",
 } as const;

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,8 @@ import * as path from "path";
  * │   ├── Apollo.md
  * │   ├── Hercules.md
  * │   ├── Chiron.md
- * │   └── Mnemosyne.md
+ * │   ├── Mnemosyne.md
+ * │   └── Aphrodite.md
  * ├── stories/                         # Working tree (gitignored)
  * │   └── <story-name>/
  * │       ├── README.md
@@ -35,6 +36,7 @@ import * as path from "path";
  * │   ├── lessons/
  * │   └── blunders/
  * ├── standards/                       # Prescriptive guidelines (committed)
+ * ├── screenshots/                     # Browser screenshots (gitignored)
  * ├── sessions/                        # Conversation records (gitignored)
  * ├── transcripts/                     # Legacy transcripts (gitignored)
  * └── openfleet.log
@@ -53,6 +55,7 @@ export const PATHS = {
   agentHercules: path.join(OPENFLEET_DIR, "agents", "Hercules.md"),
   agentChiron: path.join(OPENFLEET_DIR, "agents", "Chiron.md"),
   agentMnemosyne: path.join(OPENFLEET_DIR, "agents", "Mnemosyne.md"),
+  agentAphrodite: path.join(OPENFLEET_DIR, "agents", "Aphrodite.md"),
   sessions: path.join(OPENFLEET_DIR, "sessions"),
   stories: path.join(OPENFLEET_DIR, "stories"),
   docs: path.join(OPENFLEET_DIR, "docs"),
@@ -63,6 +66,7 @@ export const PATHS = {
   blunders: path.join(OPENFLEET_DIR, "experience", "blunders"),
   standards: path.join(OPENFLEET_DIR, "standards"),
   reviews: path.join(OPENFLEET_DIR, "reviews"),
+  screenshots: path.join(OPENFLEET_DIR, "screenshots"),
   transcripts: path.join(OPENFLEET_DIR, "transcripts"),
   logFile: path.join(OPENFLEET_DIR, "openfleet.log"),
 } as const;

--- a/src/templates/.openfleet/agents/Aphrodite.md
+++ b/src/templates/.openfleet/agents/Aphrodite.md
@@ -1,0 +1,10 @@
+# Aphrodite
+
+_Goddess of beauty and love._
+
+Your personal scratchpad. Use this for:
+
+- Site-specific quirks (anti-bot measures, slow loading, dynamic content)
+- Successful automation patterns worth reusing
+- Common element selectors and coordinates that work well
+- Tools or approaches that failed (to avoid repeating mistakes)


### PR DESCRIPTION
## Summary

- Add Aphrodite as the browser automation specialist agent for Openfleet
- Configure Playwright in headless mode as the primary tool
- Integrate with SPARR framework for consistent agent behavior

## Changes

- Create `src/agents/aphrodite.ts` with comprehensive system prompt
- Register Aphrodite in agents index and names
- Add `screenshots` path to config for storing browser captures
- Create `.openfleet/screenshots/` directory

## Aphrodite Features

- **Initial Context**: Reads status.md, personal scratchpad, and troubleshooting docs
- **Playwright Headless**: Always uses `headless=true` for browser automation
- **Workflow**: 9-step process from skill loading to reporting
- **Failure Modes**: Table with symptoms and actions for common issues
- **Reporting**: BrowserReport.md template for task outcomes
- **Safety Constraints**: Credential handling, destructive action prevention