### PR TITLE
feat: add context management for compaction hooks

### DIFF
--- a/src/context/compaction-hook.ts
+++ b/src/context/compaction-hook.ts
@@ -1,0 +1,23 @@
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import { logger } from "../logger";
+import { formatConstraintsForCompaction } from "./critical-constraints";
+
+export function createCompactionHook(_ctx: PluginInput) {
+  return {
+    "experimental.session.compacting": async (
+      input: { sessionID: string },
+      output: { context: string[]; prompt?: string },
+    ): Promise<void> => {
+      logger.info("Session compacting hook triggered", { sessionID: input.sessionID });
+
+      const constraints = formatConstraintsForCompaction();
+      output.context.push(constraints);
+
+      logger.info("Injected critical constraints into compaction context", {
+        sessionID: input.sessionID,
+        constraintLength: constraints.length,
+      });
+    },
+  };
+}

--- a/src/context/critical-constraints.ts
+++ b/src/context/critical-constraints.ts
@@ -1,0 +1,39 @@
+/**
+ * Critical constraints for Zeus (Orchestrator) that must survive context compaction.
+ *
+ * These constraints define Zeus's core identity and operational rules.
+ * They are injected into the compaction prompt via the experimental.session.compacting hook.
+ */
+
+export const ZEUS_CRITICAL_CONSTRAINTS = [
+  // Primary delegation rule
+  `CRITICAL CONSTRAINT: You are Zeus, the Orchestrator. You DO NOT WRITE ANY CODE unless the user explicitly orders you to. You delegate ALL implementation work to your specialized subagent team (Athena for research, Apollo for planning, Hercules for implementation, Chiron for review, Mnemosyne for reflection).`,
+
+  // SPARR framework
+  `CRITICAL CONSTRAINT: You follow the SPARR framework religiously: Scout (research) -> Plan (HLD/LLD) -> Act (implement) -> Review (code review) -> Reflect (lessons learned). Every task, no matter how trivial, goes through this cycle.`,
+
+  // Story board management
+  `CRITICAL CONSTRAINT: You maintain story boards in \`.openfleet/stories/\` and track all progress in \`.openfleet/status.md\`. This is your primary responsibility as Orchestrator.`,
+
+  // Git operations
+  `CRITICAL CONSTRAINT: You are in charge of git operations - creating branches, merging, committing. Branch structure mirrors story structure: feat/<story>/<task>/<branch>.`,
+];
+
+/**
+ * Format constraints for injection into compaction prompt.
+ * Returns a single formatted string suitable for the context array.
+ */
+export function formatConstraintsForCompaction(): string {
+  const header = `
+=== PRESERVED AGENT CONSTRAINTS ===
+The following constraints define the agent's core identity and MUST be maintained after context compaction:
+`;
+
+  const constraintsList = ZEUS_CRITICAL_CONSTRAINTS.map((c, i) => `${i + 1}. ${c}`).join("\n\n");
+
+  const footer = `
+=== END PRESERVED CONSTRAINTS ===
+`;
+
+  return `${header}\n${constraintsList}\n${footer}`;
+}

--- a/src/context/critical-constraints.ts
+++ b/src/context/critical-constraints.ts
@@ -1,28 +1,13 @@
-/**
- * Critical constraints for Zeus (Orchestrator) that must survive context compaction.
- *
- * These constraints define Zeus's core identity and operational rules.
- * They are injected into the compaction prompt via the experimental.session.compacting hook.
- */
-
 export const ZEUS_CRITICAL_CONSTRAINTS = [
-  // Primary delegation rule
   `CRITICAL CONSTRAINT: You are Zeus, the Orchestrator. You DO NOT WRITE ANY CODE unless the user explicitly orders you to. You delegate ALL implementation work to your specialized subagent team (Athena for research, Apollo for planning, Hercules for implementation, Chiron for review, Mnemosyne for reflection).`,
 
-  // SPARR framework
   `CRITICAL CONSTRAINT: You follow the SPARR framework religiously: Scout (research) -> Plan (HLD/LLD) -> Act (implement) -> Review (code review) -> Reflect (lessons learned). Every task, no matter how trivial, goes through this cycle.`,
 
-  // Story board management
   `CRITICAL CONSTRAINT: You maintain story boards in \`.openfleet/stories/\` and track all progress in \`.openfleet/status.md\`. This is your primary responsibility as Orchestrator.`,
 
-  // Git operations
   `CRITICAL CONSTRAINT: You are in charge of git operations - creating branches, merging, committing. Branch structure mirrors story structure: feat/<story>/<task>/<branch>.`,
 ];
 
-/**
- * Format constraints for injection into compaction prompt.
- * Returns a single formatted string suitable for the context array.
- */
 export function formatConstraintsForCompaction(): string {
   const header = `
 === PRESERVED AGENT CONSTRAINTS ===

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,2 @@
+export { createCompactionHook } from "./compaction-hook";
+export { ZEUS_CRITICAL_CONSTRAINTS, formatConstraintsForCompaction } from "./critical-constraints";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 
 import { configureAgents } from "./agents";
+import { createCompactionHook } from "./context";
 import { sleep } from "./lib/utils";
 import { logger } from "./logger";
 import { createSaveConversationTool } from "./tools/save-conversation";
@@ -14,6 +15,7 @@ const OpenfleetPlugin: Plugin = async (ctx) => {
   logger.info("Plugin loaded");
   const saveConversation = createSaveConversationTool(ctx);
   const transcriptHooks = createTranscriptHooks(ctx);
+  const compactionHook = createCompactionHook(ctx);
 
   return {
     tool: {
@@ -36,6 +38,7 @@ const OpenfleetPlugin: Plugin = async (ctx) => {
     },
 
     ...transcriptHooks,
+    ...compactionHook,
   };
 };
 


### PR DESCRIPTION
## Summary
- Add compaction hook that preserves Zeus critical constraints during session context compaction
- Define core agent constraints (SPARR framework, delegation rules, story board tracking, git operations) in `critical-constraints.ts`
- Wire compaction hook into the plugin so constraints are automatically injected when sessions compact

## Changes
- `src/context/critical-constraints.ts` — defines Zeus constraints and formatting
- `src/context/compaction-hook.ts` — hook that injects constraints into compaction context
- `src/context/index.ts` — barrel exports
- `src/index.ts` — registers the compaction hook in the plugin