### PR TITLE
feat: dynamic per-agent system prompt override via file-based hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,22 +4,23 @@
   "workspaces": {
     "": {
       "name": "openfleet",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.2",
+        "@opencode-ai/plugin": "~1.0.224",
+        "@opencode-ai/sdk": "~1.0.224",
+      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@opencode-ai/plugin": "~1.0.224",
         "@opencode-ai/sdk": "~1.0.224",
+        "@types/bun": "^1.3.10",
         "@types/node": "^22",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
-      },
-      "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.71.2",
-        "@opencode-ai/plugin": "~1.0.224",
-        "@opencode-ai/sdk": "~1.0.224",
       },
     },
   },
@@ -162,6 +163,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
@@ -177,6 +180,8 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -256,6 +261,8 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
@@ -271,6 +278,8 @@
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
@@ -293,6 +302,8 @@
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
@@ -331,6 +342,8 @@
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build": "rm -rf dist && bun build src/index.ts --outdir dist --target bun --format esm --external @opencode-ai/plugin --external @opencode-ai/sdk --external @anthropic-ai/sdk && tsc --emitDeclarationOnly && cp -r src/templates dist/",
     "dev": "tsup src/index.ts --format esm --dts --watch",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"
@@ -36,9 +38,10 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@opencode-ai/plugin": "~1.0.224",
     "@opencode-ai/sdk": "~1.0.224",
-    "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+    "@types/bun": "^1.3.10",
     "@types/node": "^22",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",

--- a/src/transcript/hooks.ts
+++ b/src/transcript/hooks.ts
@@ -1,9 +1,17 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
 import type { PluginInput } from "@opencode-ai/plugin";
 
+import { logger } from "../logger";
 import { recordToolResult, recordToolUse, recordUserMessage } from "./recorder";
 import type { SessionInfo } from "./recorder";
 
 const sessionInfoCache = new Map<string, SessionInfo>();
+const sessionAgentMap = new Map<string, string>();
+
+const WORKSPACE_DIR = process.env.WORKSPACE_DIR ?? process.cwd();
+const AGENT_OVERRIDE_DIR = path.join(WORKSPACE_DIR, ".opencode", "agents");
 
 async function getSessionInfo(ctx: PluginInput, sessionID: string): Promise<SessionInfo> {
   const cached = sessionInfoCache.get(sessionID);
@@ -32,9 +40,12 @@ async function getSessionInfo(ctx: PluginInput, sessionID: string): Promise<Sess
 export function createTranscriptHooks(ctx: PluginInput) {
   return {
     "chat.message": async (
-      input: { sessionID: string },
+      input: { sessionID: string; agent?: string },
       output: { message: unknown; parts: unknown[] },
     ) => {
+      if (input.agent) {
+        sessionAgentMap.set(input.sessionID, input.agent);
+      }
       const session = await getSessionInfo(ctx, input.sessionID);
       await recordUserMessage(session, output.message as any, output.parts as any);
     },
@@ -54,5 +65,30 @@ export function createTranscriptHooks(ctx: PluginInput) {
       const session = await getSessionInfo(ctx, input.sessionID);
       await recordToolResult(session, input.tool, input.callID, output);
     },
+
+    "experimental.chat.system.transform": (async (
+      input: { sessionID?: string; model: unknown },
+      output: { system: string[] },
+    ) => {
+      const agentName = input.sessionID ? sessionAgentMap.get(input.sessionID) : undefined;
+      if (!agentName) return;
+
+      const overridePath = path.join(AGENT_OVERRIDE_DIR, agentName, "system_prompt.md");
+      if (!overridePath.startsWith(AGENT_OVERRIDE_DIR + path.sep)) return;
+      if (!existsSync(overridePath)) return;
+
+      try {
+        const content = readFileSync(overridePath, "utf-8").trim();
+        if (content) {
+          output.system.push(content);
+        }
+      } catch (err) {
+        logger.error("Failed to read agent system prompt override", {
+          agentName,
+          overridePath,
+          err,
+        });
+      }
+    }) as (input: {}, output: { system: string[] }) => Promise<void>,
   };
 }


### PR DESCRIPTION
## Summary

- Register `experimental.chat.system.transform` hook to read per-agent `system_prompt.md` files and append content to the agent's system prompt on each LLM call
- Track `sessionID → agentName` mapping via `chat.message` hook

## How it works

1. User writes a file to `.opencode/agents/<AgentName>/system_prompt.md`
2. On every LLM call, the plugin hook reads the file and appends its content to the system prompt
3. Deleting the file reverts the agent to its base prompt
4. Changes take effect on the **next LLM call** — no restart needed

