### PR TITLE
Disable save_conversation tool — compaction hangs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 import { configureAgents } from "./agents";
 import { sleep } from "./lib/utils";
 import { logger } from "./logger";
-import { createSaveConversationTool } from "./tools/save-conversation";
 import { createTranscriptHooks } from "./transcript";
 import { getPendingMigrations, initializeDirectories, stampVersion } from "./utils/directory-init";
 import { showSpinnerToast, showToast } from "./utils/toast";
@@ -12,15 +11,14 @@ const OpenfleetPlugin: Plugin = async (ctx) => {
   initializeDirectories();
 
   logger.info("Plugin loaded");
-  const saveConversation = createSaveConversationTool(ctx);
   const transcriptHooks = createTranscriptHooks(ctx);
 
   const { event: transcriptEvent, ...otherTranscriptHooks } = transcriptHooks;
 
   return {
-    tool: {
-      save_conversation: saveConversation,
-    },
+    // save_conversation disabled — compaction hangs due to unknown model/credential issue
+    // see: https://github.com/user/starfleet/issues/TBD
+    tool: {},
 
     config: async (config) => {
       configureAgents(config);


### PR DESCRIPTION
## Summary

- Disables the `save_conversation` plugin tool which causes sessions to hang across all environments (local, staging, prod)
- The compaction flow triggered by this tool has an unresolved issue — likely related to model/credential handling during OpenCode's internal compaction LLM call
- Tool registration removed; existing `tools/save-conversation/` source preserved for when we fix the root cause

## Context

When an LLM calls `save_conversation`, the openfleet plugin fires off `POST /session/{id}/summarize` to OpenCode. This triggers a compaction LLM call inside OpenCode's prompt loop. The tool UI gets stuck showing "Saving..." indefinitely. The root cause needs further investigation — potentially related to how the compaction agent resolves its model/credentials vs the regular prompt path.